### PR TITLE
Per-campaign validations

### DIFF
--- a/app/models/concerns/campaign_validatable_model.rb
+++ b/app/models/concerns/campaign_validatable_model.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CampaignValidatableModel
+  extend ActiveSupport::Concern
+
+  included do
+    validate :campaign_validator
+  end
+
+  def campaign_validator
+    validator_class = campaign_validator_class
+    return if validator_class.nil?
+    validates_with validator_class
+  end
+
+  def campaign_validator_class_name
+    return nil unless respond_to?(:edm_provider) && edm_provider.present?
+
+    @campaign_validator_class_name ||= begin
+      'Campaigns::' + edm_provider.strip.gsub(' ', '::') + 'Validator'
+    end
+  end
+
+  def campaign_validator_class
+    class_name = campaign_validator_class_name
+    class_name.nil? ? nil : class_name.safe_constantize
+  end
+end

--- a/app/models/edm/agent.rb
+++ b/app/models/edm/agent.rb
@@ -3,6 +3,7 @@
 module EDM
   class Agent
     include Mongoid::Document
+    include CampaignValidatableModel
     include RDFModel
     include RemoveBlankAttributes
 
@@ -22,6 +23,8 @@ module EDM
     field :skos_note, localize: true
     field :foaf_mbox, type: String
     field :foaf_name, type: String
+
+    delegate :edm_provider, to: :dc_contributor_for, allow_nil: true
 
     rails_admin do
       visible false

--- a/app/models/edm/provided_cho.rb
+++ b/app/models/edm/provided_cho.rb
@@ -7,6 +7,7 @@
 module EDM
   class ProvidedCHO
     include Mongoid::Document
+    include CampaignValidatableModel
     include RDFModel
     include RemoveBlankAttributes
 
@@ -42,13 +43,14 @@ module EDM
     end
 
     delegate :edm_type_enum, :dc_language_enum, to: :class
+    delegate :edm_dataProvider, :edm_provider, to: :ore_aggregation
 
     before_validation :derive_edm_type_from_edm_isShownBy, unless: :edm_type?
 
     validates :dc_description, presence: true, unless: :dc_title?
+    validates :dc_language, inclusion: { in: dc_language_enum.map(&:last) }, allow_blank: true
     validates :dc_title, presence: true, unless: :dc_description?
     validates :edm_type, inclusion: { in: edm_type_enum }, presence: true
-    validates :dc_language, inclusion: { in: dc_language_enum.map(&:last) }, allow_blank: true
 
     accepts_nested_attributes_for :dc_creator, :dc_contributor, reject_if: :all_blank
 

--- a/app/models/edm/provided_cho.rb
+++ b/app/models/edm/provided_cho.rb
@@ -43,7 +43,7 @@ module EDM
     end
 
     delegate :edm_type_enum, :dc_language_enum, to: :class
-    delegate :edm_dataProvider, :edm_provider, to: :ore_aggregation
+    delegate :edm_dataProvider, :edm_provider, to: :ore_aggregation, allow_nil: true
 
     before_validation :derive_edm_type_from_edm_isShownBy, unless: :edm_type?
 

--- a/app/validators/campaign_validator.rb
+++ b/app/validators/campaign_validator.rb
@@ -15,4 +15,8 @@ class CampaignValidator < ActiveModel::Validator
     record_class = record.class.to_s.underscore.tr('/', '_')
     :"validate_#{record_class}"
   end
+
+  def validate_presence_of(record, attr)
+    record.errors.add(attr, I18n.t('errors.messages.blank')) unless record.send(:"#{attr}?")
+  end
 end

--- a/app/validators/campaign_validator.rb
+++ b/app/validators/campaign_validator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Model validations for stories submitted within one campaign
+class CampaignValidator < ActiveModel::Validator
+  def validate(record)
+    method_name = validation_method_name(record)
+    send(method_name, record) if respond_to?(method_name, true)
+  end
+
+  protected
+
+  # @example
+  #   validation_method_name(ORE::Aggregation.new) #=> :validate_ore_aggregation
+  def validation_method_name(record)
+    record_class = record.class.to_s.underscore.tr('/', '_')
+    :"validate_#{record_class}"
+  end
+end

--- a/app/validators/campaigns/europeana/migration_validator.rb
+++ b/app/validators/campaigns/europeana/migration_validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Campaigns
+  module Europeana
+    # Model validations for stories submitted in the Migration campaign
+    class MigrationValidator < CampaignValidator
+      protected
+
+      def validate_edm_provided_cho(record)
+        record.errors.add(:dc_title, I18n.t('errors.messages.blank')) unless record.dc_title?
+        record.errors.add(:dc_description, I18n.t('errors.messages.blank')) unless record.dc_description?
+      end
+
+      def validate_edm_agent(record)
+        return unless record.dc_contributor_for?
+        record.errors.add(:foaf_mbox, I18n.t('errors.messages.blank')) unless record.foaf_mbox?
+        record.errors.add(:foaf_name, I18n.t('errors.messages.blank')) unless record.foaf_name?
+        record.errors.add(:skos_prefLabel, I18n.t('errors.messages.blank')) unless record.skos_prefLabel?
+      end
+    end
+  end
+end

--- a/app/validators/campaigns/europeana/migration_validator.rb
+++ b/app/validators/campaigns/europeana/migration_validator.rb
@@ -7,15 +7,16 @@ module Campaigns
       protected
 
       def validate_edm_provided_cho(record)
-        record.errors.add(:dc_title, I18n.t('errors.messages.blank')) unless record.dc_title?
-        record.errors.add(:dc_description, I18n.t('errors.messages.blank')) unless record.dc_description?
+        %i(dc_title dc_description).each do |attr|
+          validate_presence_of(record, attr)
+        end
       end
 
       def validate_edm_agent(record)
         return unless record.dc_contributor_for?
-        record.errors.add(:foaf_mbox, I18n.t('errors.messages.blank')) unless record.foaf_mbox?
-        record.errors.add(:foaf_name, I18n.t('errors.messages.blank')) unless record.foaf_name?
-        record.errors.add(:skos_prefLabel, I18n.t('errors.messages.blank')) unless record.skos_prefLabel?
+        %i(foaf_mbox foaf_name skos_prefLabel).each do |attr|
+          validate_presence_of(record, attr)
+        end
       end
     end
   end

--- a/spec/fixtures/cc/licenses.yml
+++ b/spec/fixtures/cc/licenses.yml
@@ -1,4 +1,0 @@
-publicdomain_mark:
-  rdf_about: https://creativecommons.org/publicdomain/mark/1.0/
-publicdomain_zero:
-  rdf_about: https://creativecommons.org/publicdomain/zero/1.0/

--- a/spec/models/concerns/campaign_validatable_model_spec.rb
+++ b/spec/models/concerns/campaign_validatable_model_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe CampaignValidatableModel do
+  before(:all) do
+    module Campaigns
+      module Test
+        class ProviderValidator < ActiveModel::Validator
+          def validate(record)
+            record.errors.add(:base, 'invalid')
+          end
+        end
+      end
+    end
+  end
+
+  let(:model_class) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Validations
+      include CampaignValidatableModel
+
+      attr_accessor :edm_provider, :dc_title
+    end
+  end
+
+  let(:edm_provider_without_validator_class) { 'Some Provider' }
+  let(:edm_provider_with_validator_class) { 'Test Provider' }
+
+  describe '#campaign_validator_class_name' do
+    context 'with edm_provider' do
+      subject { model_class.new(edm_provider: edm_provider_without_validator_class) }
+
+      it 'constructs validator class name from edm_provider' do
+        expect(subject.campaign_validator_class_name).to eq('Campaigns::Some::ProviderValidator')
+      end
+    end
+
+    context 'without edm_provider' do
+      subject { model_class.new.campaign_validator_class_name }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#campaign_validator_class' do
+    context 'with edm_provider' do
+      context 'without validator class defined' do
+        subject { model_class.new(edm_provider: edm_provider_without_validator_class).campaign_validator_class }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'with validator class defined' do
+        subject { model_class.new(edm_provider: edm_provider_with_validator_class) }
+
+        it 'returns validator class derived from edm_provider' do
+          expect(subject.campaign_validator_class).to eq(Campaigns::Test::ProviderValidator)
+        end
+      end
+    end
+
+    context 'without edm_provider' do
+      subject { model_class.new.campaign_validator_class }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#campaign_validator' do
+    context 'with edm_provider' do
+      context 'without validator class defined' do
+        subject { model_class.new(edm_provider: edm_provider_without_validator_class) }
+
+        it 'does not add any validations' do
+          expect(subject).to be_valid
+        end
+      end
+
+      context 'with validator class defined' do
+        subject { model_class.new(edm_provider: edm_provider_with_validator_class) }
+
+        it 'runs validations from validator class' do
+          expect(subject).not_to be_valid
+        end
+      end
+    end
+
+    context 'without edm_provider' do
+      subject { model_class.new }
+
+      it 'does not add any validations' do
+        expect(subject).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/edm/agent_spec.rb
+++ b/spec/models/edm/agent_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe EDM::Agent do
   describe 'modules' do
     subject { described_class }
     it { is_expected.to include(Mongoid::Document) }
+    it { is_expected.to include(CampaignValidatableModel) }
     it { is_expected.to include(RDFModel) }
     it { is_expected.to include(RemoveBlankAttributes) }
   end

--- a/spec/models/edm/provided_cho_spec.rb
+++ b/spec/models/edm/provided_cho_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe EDM::ProvidedCHO do
   describe 'modules' do
     subject { described_class }
     it { is_expected.to include(Mongoid::Document) }
+    it { is_expected.to include(CampaignValidatableModel) }
     it { is_expected.to include(RDFModel) }
     it { is_expected.to include(RemoveBlankAttributes) }
   end

--- a/spec/validators/campaign_validator_spec.rb
+++ b/spec/validators/campaign_validator_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe CampaignValidator do
+  let(:validator_class) do
+    Class.new(CampaignValidator) do
+      def validate_edm_agent(_record); end
+    end
+  end
+
+  subject { validator_class.new }
+
+  describe '#validate' do
+    context 'with validation method for record class' do
+      let(:record_class) { EDM::Agent }
+      let(:validation_method) { 'validate_edm_agent' }
+
+      it 'calls validation method' do
+        expect(subject).to receive(:validate_edm_agent)
+        subject.validate(record_class.new)
+      end
+    end
+
+    context 'without validation method for record class' do
+      let(:record_class) { EDM::Place }
+      let(:validation_method) { 'validate_edm_place' }
+
+      it 'does not raise exception' do
+        expect { subject.validate(record_class.new) }.not_to raise_exception
+      end
+    end
+  end
+end

--- a/spec/validators/campaigns/europeana/migration_validator_spec.rb
+++ b/spec/validators/campaigns/europeana/migration_validator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Campaigns::Europeana::MigrationValidator do
+  let(:aggregation) do
+    build(:ore_aggregation, edm_provider: 'Europeana Migration').tap do |aggregation|
+      aggregation.edm_aggregatedCHO = build(:edm_provided_cho, dc_title: nil, dc_description: nil)
+      aggregation.edm_aggregatedCHO.dc_contributor = build(:edm_agent)
+      aggregation.edm_aggregatedCHO.dc_creator = build(:edm_agent)
+    end
+  end
+
+  context 'when record is EDM::ProvidedCHO' do
+    subject { aggregation.edm_aggregatedCHO }
+
+    it 'validates presence of dc_title' do
+      subject.validate
+      expect(subject.errors[:dc_title]).to include(I18n.t('errors.messages.blank'))
+    end
+
+    it 'validates presence of dc_description' do
+      subject.validate
+      expect(subject.errors[:dc_description]).to include(I18n.t('errors.messages.blank'))
+    end
+  end
+
+  context 'when record is EDM::Agent' do
+    context 'when record is for dc_contributor' do
+      subject { aggregation.edm_aggregatedCHO.dc_contributor }
+
+      it 'validates presence of foaf_mbox' do
+        subject.validate
+        expect(subject.errors[:foaf_mbox]).to include(I18n.t('errors.messages.blank'))
+      end
+
+      it 'validates presence of foaf_name' do
+        subject.validate
+        expect(subject.errors[:foaf_name]).to include(I18n.t('errors.messages.blank'))
+      end
+
+      it 'validates presence of skos_prefLabel' do
+        subject.validate
+        expect(subject.errors[:skos_prefLabel]).to include(I18n.t('errors.messages.blank'))
+      end
+    end
+
+    context 'when record is not for dc_contributor' do
+      subject { aggregation.edm_aggregatedCHO.dc_creator }
+
+      it 'does not validate presence of foaf_mbox' do
+        subject.validate
+        expect(subject.errors[:foaf_mbox]).not_to include(I18n.t('errors.messages.blank'))
+      end
+
+      it 'does not validate presence of foaf_name' do
+        subject.validate
+        expect(subject.errors[:foaf_name]).not_to include(I18n.t('errors.messages.blank'))
+      end
+
+      it 'does not validate presence of skos_prefLabel' do
+        subject.validate
+        expect(subject.errors[:skos_prefLabel]).not_to include(I18n.t('errors.messages.blank'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the context of a particular UGC campaign (Migration, WWI, etc), it may be desired to have field validations only relevant to that campaign. These do not therefore belong in the model classes themselves, but need to be applied to the various models when, and only when, they are created in the context of that campaign.

This PR approaches this requirement by implementing support for auto-detected campaign-specific validators.
  