### PR TITLE
Autocompletable fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :production do
 end
 
 group :development do
+  gem 'brakeman'
   gem 'foreman'
   gem 'listen'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     bindex (0.5.0)
     binding_of_caller (0.7.3)
       debug_inspector (>= 0.0.1)
+    brakeman (4.1.1)
     bson (4.2.2)
     builder (3.2.3)
     byebug (9.1.0)
@@ -390,6 +391,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  brakeman
   byebug
   carrierwave-mongoid
   colorize

--- a/app/controllers/concerns/autocompleted_fields.rb
+++ b/app/controllers/concerns/autocompleted_fields.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module AutocompletedFields
+  extend ActiveSupport::Concern
+
+  def autocomplete(object, attribute_name, **options)
+    object.extend(AutocompletableModel) unless object.is_a?(AutocompletableModel)
+    object.autocompletes(attribute_name, options)
+  end
+end

--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -67,7 +67,8 @@ class MigrationController < ApplicationController
                :dc_identifier, :dc_title, :dc_description, :dc_language, :dc_subject_text,
                :dc_subject_value, :dc_type, :dcterms_created, :edm_wasPresentAt_id, {
                  dc_contributor_attributes: %i(foaf_mbox foaf_name skos_prefLabel),
-                 dc_creator_attributes: %i(foaf_name rdaGr2_dateOfBirth rdaGr2_dateOfDeath rdaGr2_placeOfBirth rdaGr2_placeOfDeath)
+                 dc_creator_attributes: %i(foaf_name rdaGr2_dateOfBirth rdaGr2_dateOfDeath rdaGr2_placeOfBirth_text
+                                           rdaGr2_placeOfBirth_value rdaGr2_placeOfDeath_text rdaGr2_placeOfDeath_value)
                }
              ],
              edm_isShownBy_attributes: [:dc_description, :dc_type, :dcterms_created, :media, :media_cache, {

--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class MigrationController < ApplicationController
+  include AutocompletedFields
   include LocalisableByDCLanguage
 
   layout false
@@ -42,6 +43,10 @@ class MigrationController < ApplicationController
       aggregation.edm_aggregatedCHO.build_dc_contributor
       aggregation.edm_aggregatedCHO.build_dc_creator
       aggregation.build_edm_isShownBy
+
+      autocomplete(aggregation.edm_aggregatedCHO, :dc_subject, url: vocabularies_unesco_path, param: 'q')
+      autocomplete(aggregation.edm_aggregatedCHO.dc_creator, :rdaGr2_placeOfBirth, url: vocabularies_europeana_places_path, param: 'q')
+      autocomplete(aggregation.edm_aggregatedCHO.dc_creator, :rdaGr2_placeOfDeath, url: vocabularies_europeana_places_path, param: 'q')
     end
   end
 
@@ -59,7 +64,8 @@ class MigrationController < ApplicationController
   def aggregation_params
     params.require(:ore_aggregation).
       permit(edm_aggregatedCHO_attributes: [
-               :dc_title, :dc_description, :dc_language, :dc_subject, :dc_type, :dcterms_created, {
+               :dc_identifier, :dc_title, :dc_description, :dc_language, :dc_subject_text,
+               :dc_subject_value, :dc_type, :dcterms_created, :edm_wasPresentAt_id, {
                  dc_contributor_attributes: %i(foaf_mbox foaf_name skos_prefLabel),
                  dc_creator_attributes: %i(foaf_name rdaGr2_dateOfBirth rdaGr2_dateOfDeath rdaGr2_placeOfBirth rdaGr2_placeOfDeath)
                }

--- a/app/controllers/vocabularies/europeana/places_controller.rb
+++ b/app/controllers/vocabularies/europeana/places_controller.rb
@@ -38,10 +38,12 @@ module Vocabularies
 
       # Find and return the first candidate matching the regex
       def index_result_text_matching_query(candidates)
-        regex = /\b#{params[:q]}/i
+        query = params[:q].downcase
 
         candidates.each do |candidate|
-          match = [candidate].flatten.detect { |value| !!(value =~ regex) }
+          match = [candidate].flatten.compact.detect do |value|
+            value.downcase.split(/\b/).any? { |fragment| fragment.start_with?(query) }
+          end
           return match unless match.nil?
         end
 

--- a/app/controllers/vocabularies/europeana/places_controller.rb
+++ b/app/controllers/vocabularies/europeana/places_controller.rb
@@ -10,13 +10,53 @@ module Vocabularies
                        },
                        query: :text,
                        results: 'items',
-                       text: lambda { |result|
-                         result['prefLabel'][I18n.locale.to_s] ||
-                           result['prefLabel'][I18n.default_locale.to_s] ||
-                           result['prefLabel'][''] ||
-                           result['prefLabel'].values.first
-                       },
+                       text: :index_result_text,
                        value: 'id'
+
+      protected
+
+      def index_result_text(result)
+        candidates = index_result_text_candidates(result)
+
+        index_result_text_matching_query(candidates) ||
+          index_result_text_present(candidates)
+      end
+
+      def index_result_text_candidates(result)
+        result['altLabel'] ||= {}
+        [
+          result['prefLabel'][I18n.locale.to_s],
+          result['altLabel'][I18n.locale.to_s],
+          result['prefLabel'][I18n.default_locale.to_s],
+          result['altLabel'][I18n.default_locale.to_s],
+          result['prefLabel'][''],
+          result['altLabel'][''],
+          result['prefLabel'].values,
+          result['altLabel'].values
+        ]
+      end
+
+      # Find and return the first candidate matching the regex
+      def index_result_text_matching_query(candidates)
+        regex = /\b#{params[:q]}/i
+
+        candidates.each do |candidate|
+          match = [candidate].flatten.detect { |value| !!(value =~ regex) }
+          return match unless match.nil?
+        end
+
+        nil
+      end
+
+      # Find and the first non-blank candidate
+      def index_result_text_present(candidates)
+        candidates.each do |candidate|
+          present = [candidate].flatten.detect { |value| value.present? }
+          return present unless present.nil?
+        end
+
+        nil
+      end
     end
   end
 end

--- a/app/controllers/vocabularies/europeana/places_controller.rb
+++ b/app/controllers/vocabularies/europeana/places_controller.rb
@@ -53,7 +53,7 @@ module Vocabularies
       # Find and the first non-blank candidate
       def index_result_text_present(candidates)
         candidates.each do |candidate|
-          present = [candidate].flatten.detect { |value| value.present? }
+          present = [candidate].flatten.detect(&:present?)
           return present unless present.nil?
         end
 

--- a/app/controllers/vocabularies/unesco_controller.rb
+++ b/app/controllers/vocabularies/unesco_controller.rb
@@ -19,12 +19,11 @@ module Vocabularies
 
     # matches may be in either prefLabel or altLabel
     def index_result_text(result)
-      query = params[:q]
-      regex = /\A#{query}/i
+      query = params[:q].downcase
 
-      if !!(result['prefLabel'] =~ regex)
+      if result['prefLabel'].downcase.start_with?(query)
         result['prefLabel']
-      elsif !!(result['altLabel'] =~ regex)
+      elsif result['altLabel'].downcase.start_with?(query)
         result['altLabel']
       else
         result['prefLabel']

--- a/app/controllers/vocabularies/unesco_controller.rb
+++ b/app/controllers/vocabularies/unesco_controller.rb
@@ -8,13 +8,27 @@ module Vocabularies
                      },
                      query: :query,
                      results: 'results',
-                     text: 'prefLabel',
+                     text: :index_result_text,
                      value: 'uri'
 
     protected
 
     def index_query
       "#{params[:q]}*"
+    end
+
+    # matches may be in either prefLabel or altLabel
+    def index_result_text(result)
+      query = params[:q]
+      regex = /\A#{query}/i
+
+      if !!(result['prefLabel'] =~ regex)
+        result['prefLabel']
+      elsif !!(result['altLabel'] =~ regex)
+        result['altLabel']
+      else
+        result['prefLabel']
+      end
     end
   end
 end

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -52,7 +52,13 @@ class VocabulariesController < ApplicationController
     end
   end
 
-  def call_or_fetch(proc_or_key, hash)
-    proc_or_key.respond_to?(:call) ? proc_or_key.call(hash) : hash[proc_or_key]
+  def call_or_fetch(method_name_or_proc_or_key, hash)
+    if method_name_or_proc_or_key.respond_to?(:call)
+      method_name_or_proc_or_key.call(hash)
+    elsif method_name_or_proc_or_key.is_a?(Symbol)
+      send(method_name_or_proc_or_key, hash)
+    else
+      hash[method_name_or_proc_or_key]
+    end
   end
 end

--- a/app/inputs/autocomplete_input.rb
+++ b/app/inputs/autocomplete_input.rb
@@ -19,7 +19,7 @@ class AutocompleteInput < SimpleForm::Inputs::StringInput
   end
 
   def autocomplete_options
-    @builder.object.autocompleted_attributes[attribute_name][:options]
+    @builder.object.autocomplete_attributes[attribute_name][:options]
   end
 
   def label_target
@@ -27,10 +27,10 @@ class AutocompleteInput < SimpleForm::Inputs::StringInput
   end
 
   def value_attribute_name
-    :"#{attribute_name}_value"
+    @builder.object.autocomplete_attributes[attribute_name][:names][:value]
   end
 
   def text_attribute_name
-    :"#{attribute_name}_text"
+    @builder.object.autocomplete_attributes[attribute_name][:names][:text]
   end
 end

--- a/app/inputs/autocomplete_input.rb
+++ b/app/inputs/autocomplete_input.rb
@@ -8,14 +8,11 @@ class AutocompleteInput < SimpleForm::Inputs::StringInput
 
     merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
 
-    text_input_options = merged_input_options.deep_dup
-    text_input_options[:class] << :'autocomplete-text'
+    hidden = @builder.hidden_field(value_attribute_name)
+    hidden_id = hidden.match(/id="(.*?)"/)[1]
 
-    hidden_input_options = merged_input_options.deep_dup
-    hidden_input_options[:class] << :'autocomplete-value'
-
-    @builder.hidden_field(value_attribute_name, hidden_input_options) +
-      @builder.text_field(text_attribute_name, text_input_options)
+    text_field_options = merged_input_options.merge('data-for': hidden_id)
+    hidden + @builder.text_field(text_attribute_name, text_field_options)
   end
 
   def autocomplete_options

--- a/app/inputs/autocomplete_input.rb
+++ b/app/inputs/autocomplete_input.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AutocompleteInput < SimpleForm::Inputs::StringInput
+  def input(wrapper_options = nil)
+    autocomplete_options.each_pair do |k, v|
+      input_html_options[:"data-#{k}"] ||= v
+    end
+
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+    text_input_options = merged_input_options.deep_dup
+    text_input_options[:class] << :'autocomplete-text'
+
+    hidden_input_options = merged_input_options.deep_dup
+    hidden_input_options[:class] << :'autocomplete-value'
+
+    @builder.hidden_field(value_attribute_name, hidden_input_options) +
+      @builder.text_field(text_attribute_name, text_input_options)
+  end
+
+  def autocomplete_options
+    @builder.object.autocompleted_attributes[attribute_name][:options]
+  end
+
+  def label_target
+    text_attribute_name
+  end
+
+  def value_attribute_name
+    :"#{attribute_name}_value"
+  end
+
+  def text_attribute_name
+    :"#{attribute_name}_text"
+  end
+end

--- a/app/models/concerns/autocompletable_model.rb
+++ b/app/models/concerns/autocompletable_model.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module AutocompletableModel
+  extend ActiveSupport::Concern
+
+  def autocompletes(attribute_name, **options)
+    @autocompleted_attributes ||= {}
+    @autocompleted_attributes[attribute_name] = {}
+    @autocompleted_attributes[attribute_name][:options] = options
+
+    unless respond_to?(:autocompleted_attributes)
+      define_singleton_method(:autocompleted_attributes) do
+        @autocompleted_attributes
+      end
+    end
+
+    define_singleton_method("#{attribute_name}_text") do
+      @autocompleted_attributes[attribute_name][:value]
+    end
+
+    define_singleton_method(:"#{attribute_name}_text=") do |value|
+      @autocompleted_attributes[attribute_name][:value] = value
+    end
+
+    define_singleton_method("#{attribute_name}_value") do
+      attributes[attribute_name]
+    end
+
+    define_singleton_method(:"#{attribute_name}_value=") do |value|
+      attributes[attribute_name] = value
+    end
+  end
+end

--- a/app/views/migration/_form.html.erb
+++ b/app/views/migration/_form.html.erb
@@ -7,7 +7,7 @@
           <%= contributor.input(:skos_prefLabel, required: true) %>
           <%= contributor.input(:foaf_mbox, as: :email, required: true) %>
         <% end %>
-        <%= cho.association(:edm_wasPresentAt, label_method: :name) %>
+        <%= cho.association(:edm_wasPresentAt, include_blank: :translate) %>
         <%= cho.input(:dc_identifier) %>
       <% end %>
       

--- a/app/views/migration/_form.html.erb
+++ b/app/views/migration/_form.html.erb
@@ -15,16 +15,16 @@
         <%= cho.input(:dc_language, as: :select, required: true, collection: EDM::ProvidedCHO.dc_language_enum) %>
         <%= cho.input(:dc_title, required: true) %>
         <%= cho.input(:dc_description, as: :text, required: true, input_html: { rows: 10 }) %>
-        <%= cho.input(:dc_subject, input_html: { 'data-url': vocabularies_unesco_path, 'data-param': 'q' }) %>
+        <%= cho.input(:dc_subject, as: :autocomplete) %>
         <% # Where did the migration begin? %>
         <% # Where did the migration end? %>
         <%= field_set_tag(i18n.t('legends.subject_agent')) do %>
           <%= cho.simple_fields_for(:dc_creator) do |creator| %>
             <%= creator.input(:foaf_name) %>
             <%= creator.input(:rdaGr2_dateOfBirth, as: :date, html5: true) %>
-            <%= creator.input(:rdaGr2_placeOfBirth, input_html: { 'data-url': vocabularies_europeana_places_path, 'data-param': 'q' }) %>
+            <%= creator.input(:rdaGr2_placeOfBirth) %>
             <%= creator.input(:rdaGr2_dateOfDeath, as: :date, html5: true) %>
-            <%= creator.input(:rdaGr2_placeOfDeath, input_html: { 'data-url': vocabularies_europeana_places_path, 'data-param': 'q' }) %>
+            <%= creator.input(:rdaGr2_placeOfDeath) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/migration/_form.html.erb
+++ b/app/views/migration/_form.html.erb
@@ -22,9 +22,9 @@
           <%= cho.simple_fields_for(:dc_creator) do |creator| %>
             <%= creator.input(:foaf_name) %>
             <%= creator.input(:rdaGr2_dateOfBirth, as: :date, html5: true) %>
-            <%= creator.input(:rdaGr2_placeOfBirth) %>
+            <%= creator.input(:rdaGr2_placeOfBirth, as: :autocomplete) %>
             <%= creator.input(:rdaGr2_dateOfDeath, as: :date, html5: true) %>
-            <%= creator.input(:rdaGr2_placeOfDeath) %>
+            <%= creator.input(:rdaGr2_placeOfDeath, as: :autocomplete) %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/migration.en.yml
+++ b/config/locales/migration.en.yml
@@ -11,7 +11,7 @@ en:
                 skos_prefLabel: This will be displayed alongside your submission
           include_blanks:
             edm_aggregatedCHO:
-              edm_wasPresentAt: No
+              edm_wasPresentAt: "No"
           labels:
             defaults:
               dc_description: What is this object?

--- a/spec/controllers/migration_controller_spec.rb
+++ b/spec/controllers/migration_controller_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe MigrationController do
       expect(assigns(:aggregation).edm_isShownBy).not_to be_nil
     end
 
+    it 'marks fields for autocompletion' do
+      get :new
+      expect(assigns(:aggregation).edm_aggregatedCHO).to be_a(AutocompletableModel)
+      expect(assigns(:aggregation).edm_aggregatedCHO.autocomplete_attributes).to have_key(:dc_subject)
+      expect(assigns(:aggregation).edm_aggregatedCHO.dc_creator).to be_a(AutocompletableModel)
+      expect(assigns(:aggregation).edm_aggregatedCHO.dc_creator.autocomplete_attributes).to have_key(:rdaGr2_placeOfBirth)
+      expect(assigns(:aggregation).edm_aggregatedCHO.dc_creator.autocomplete_attributes).to have_key(:rdaGr2_placeOfDeath)
+    end
+
     it 'renders the new HTML template' do
       get :new
       expect(response.status).to eq(200)

--- a/spec/models/concerns/autocompletable_model_spec.rb
+++ b/spec/models/concerns/autocompletable_model_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+RSpec.describe AutocompletableModel do
+  let(:model_class) do
+    Class.new do
+      attr_writer :attributes
+
+      def attributes
+        @attributes ||= {}
+      end
+    end
+  end
+
+  subject do
+    model_class.new.tap do |instance|
+      instance.extend(AutocompletableModel)
+    end
+  end
+
+  describe '#autocompletes' do
+    it 'defines singleton _value accessors' do
+      expect(subject).not_to respond_to(:title_value)
+      expect(subject).not_to respond_to(:title_value=)
+      subject.autocompletes(:title)
+      expect(subject).to respond_to(:title_value)
+      expect(subject).to respond_to(:title_value=)
+    end
+
+    it 'defines singleton _text accessors' do
+      expect(subject).not_to respond_to(:title_text)
+      expect(subject).not_to respond_to(:title_text=)
+      subject.autocompletes(:title)
+      expect(subject).to respond_to(:title_text)
+      expect(subject).to respond_to(:title_text=)
+    end
+
+    it 'defines #autocomplete_attributes' do
+      expect(subject).not_to respond_to(:autocomplete_attributes)
+      subject.autocompletes(:description)
+      expect(subject).to respond_to(:autocomplete_attributes)
+      expect(subject.autocomplete_attributes).to be_a(Hash)
+      expect(subject.autocomplete_attributes[:description]).to be_a(Hash)
+    end
+
+    describe '#autocomplete_attributes' do
+      let(:attribute_name) { :description }
+      let(:options) { { this: :that, something: :else } }
+
+      it 'stores arbitrary supplied options' do
+        subject.autocompletes(attribute_name, options)
+        expect(subject.autocomplete_attributes[attribute_name][:options]).to eq(options)
+      end
+
+      it 'stores text/value field names' do
+        subject.autocompletes(attribute_name, options)
+        expect(subject.autocomplete_attributes[attribute_name][:names][:text]).to eq(:"#{attribute_name}_text")
+        expect(subject.autocomplete_attributes[attribute_name][:names][:value]).to eq(:"#{attribute_name}_value")
+      end
+    end
+
+    context 'when attribute is :title' do
+      let(:attribute_name) { :title }
+
+      describe '#title_text' do
+        it 'returns title text from autocomplete_attributes' do
+          subject.autocompletes(attribute_name)
+          subject.autocomplete_attributes[attribute_name][:value] = 'text'
+          expect(subject.title_text).to eq('text')
+        end
+      end
+
+      describe '#title_text=' do
+        it 'stores title text in autocomplete_attributes' do
+          subject.autocompletes(attribute_name)
+          subject.title_text = 'text'
+          expect(subject.autocomplete_attributes[attribute_name][:value]).to eq('text')
+        end
+      end
+
+      describe '#title_value' do
+        it 'returns title value from attributes' do
+          subject.autocompletes(attribute_name)
+          subject.attributes[attribute_name] = 'value'
+          expect(subject.title_value).to eq('value')
+        end
+      end
+
+      describe '#title_value=' do
+        it 'stores title value in attributes' do
+          subject.autocompletes(attribute_name)
+          subject.title_value = 'value'
+          expect(subject.attributes[attribute_name]).to eq('value')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Re: https://europeana.atlassian.net/browse/EC-2616

Functional requirements:
- Autocomplete displays natural language labels
- Autocomplete sets a hidden input field's value to the URI associated with the natural language label
- Submitting a form with autocomplete selection submits both label and URI
- If the form has errors and is re-shown, both label and URI are present (as text and hidden fields, respectively)
- When saved, only the URI is stored

Implementation:
Preserving both label and URI across form submission requires multiple fields, which are defined as attributes on the Mongoid documents with the concern `AutocompletableModel`, which creates singleton methods on individual instances of models, the application of which is triggered in the controller. This is not ideal, but achieves the required per-campaign autocompletion support without polluting the core models.