### PR TITLE
User authorisation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'europeana-i18n', github: 'europeana/europeana-i18n-ruby', branch: 'develop'
 gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', branch: 'develop'
 
 # rubygems.org
+gem 'cancancan'
 gem 'carrierwave-mongoid'
 gem 'colorize'
 gem 'devise'

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'europeana-styleguide', github: 'europeana/europeana-styleguide-ruby', branc
 
 # rubygems.org
 gem 'cancancan'
+gem 'cancancan-mongoid'
 gem 'carrierwave-mongoid'
 gem 'colorize'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     bson (4.2.2)
     builder (3.2.3)
     byebug (9.1.0)
+    cancancan (2.1.2)
     carrierwave (1.2.1)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -410,6 +411,7 @@ DEPENDENCIES
   binding_of_caller
   brakeman
   byebug
+  cancancan
   carrierwave-mongoid
   colorize
   database_cleaner

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     builder (3.2.3)
     byebug (9.1.0)
     cancancan (2.1.2)
+    cancancan-mongoid (2.0.0.beta1)
+      cancancan (~> 2.0)
     carrierwave (1.2.1)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -412,6 +414,7 @@ DEPENDENCIES
   brakeman
   byebug
   cancancan
+  cancancan-mongoid
   carrierwave-mongoid
   colorize
   database_cleaner

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Ability
   include CanCan::Ability
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,15 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Guest users have no privileged access
+    return unless user.present?
+
+    case user.role
+    when :admin
+      can :manage, :all
+    when :events
+      # can what?
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,19 +40,31 @@ class User
   # field :unlock_token,    type: String # Only if unlock strategy is :email or :both
   # field :locked_at,       type: Time
 
+  field :role, type: Symbol
+
+  def self.role_enum
+    %i(admin events)
+  end
+  delegate :role_enum, to: :class
+
   validates :password_confirmation, presence: true, if: :encrypted_password_changed?
+  validates :role, presence: true, inclusion: { in: User.role_enum }
 
   rails_admin do
     object_label_method { :email }
 
     list do
       field :email
+      field :role
       field :current_sign_in_at
       field :current_sign_in_ip
     end
 
     edit do
       field :email do
+        required true
+      end
+      field :role, :enum do
         required true
       end
       field :password do

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -23,7 +23,7 @@ RailsAdmin.config do |config|
   config.current_user_method(&:current_user)
 
   ## == Cancan ==
-  # config.authorize_with :cancan
+  config.authorize_with :cancan
 
   ## == Pundit ==
   # config.authorize_with :pundit

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -3,7 +3,7 @@
 namespace :user do
   desc 'Create a user account from EMAIL and PASSWORD'
   task create: :environment do
-    user = User.new(email: ENV['EMAIL'], password: ENV['PASSWORD'])
+    user = User.new(email: ENV['EMAIL'], password: ENV['PASSWORD'], password_confirmation: ENV['PASSWORD'])
     if user.save
       puts 'Created'.bold.green + %( user with email "#{user.email}").green
     else

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 namespace :user do
-  desc 'Create a user account from EMAIL and PASSWORD'
+  desc 'Create an admin user account from EMAIL and PASSWORD'
   task create: :environment do
-    user = User.new(email: ENV['EMAIL'], password: ENV['PASSWORD'], password_confirmation: ENV['PASSWORD'])
+    user = User.new(email: ENV['EMAIL'], password: ENV['PASSWORD'], password_confirmation: ENV['PASSWORD'], role: :admin)
     if user.save
       puts 'Created'.bold.green + %( user with email "#{user.email}").green
     else

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user, class: User do
+    email Forgery::Internet.email_address
+    password 'pwaSBtAnSHRJ'
+    password_confirmation 'pwaSBtAnSHRJ'
+    role :admin
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe User do
+  subject { build(:user) }
+
+  describe '#role' do
+    it { is_expected.to respond_to(:role) }
+
+    context 'when :admin' do
+      subject { build(:user, role: :admin) }
+      it { is_expected.to be_valid }
+    end
+
+    context 'when :events' do
+      subject { build(:user, role: :events) }
+      it { is_expected.to be_valid }
+    end
+
+    context 'when unknown' do
+      subject { build(:user, role: :unknown) }
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe 'password confirmation' do
+    let(:password) { Forgery::Basic.password }
+
+    context 'when provided' do
+      subject { build(:user, password: password, password_confirmation: password) }
+      it { is_expected.to be_valid }
+    end
+
+    context 'when not provided' do
+      subject { build(:user, password: password, password_confirmation: nil) }
+      it { is_expected.not_to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
- Introduces CanCanCan into the bundle to perform user authorisation
- Adds a role field to the user model to store the role a user belongs to

Any existing user accounts will not be able to log in but will need to be manually assigned the admin role from a console with: `bundle exec rails r "User.each { |u| u.update_attributes(role: :admin) }"`