### PR TITLE
Stories table view

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/europeana/europeana-styleguide-ruby.git
-  revision: 989e4e2b54c502a52a6097c7ad768e38916d9f50
+  revision: b873a744172bee5354e7f50c11454887a1408a53
   branch: develop
   specs:
     europeana-styleguide (0.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/europeana/europeana-styleguide-ruby.git
-  revision: b873a744172bee5354e7f50c11454887a1408a53
+  revision: 9c4b6ceb9f01f6a8f31440e235a96f2fad60c76a
   branch: develop
   specs:
     europeana-styleguide (0.3.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  rescue_from CanCan::AccessDenied, with: :http_403_forbidden
+
+  private
+
+  def http_403_forbidden
+    render plain: 'Forbidden', status: 403
+  end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -6,7 +6,17 @@ class StoriesController < ApplicationController
   # TODO: filter events by authorisation
   def index
     authorize! :index, ORE::Aggregation
-    @stories = ORE::Aggregation.all
-    @events = EDM::Event.all
+    @stories = ORE::Aggregation.where(index_query)
+    @events = EDM::Event.where({})
+  end
+
+  protected
+
+  def index_query
+    {}.tap do |query|
+      if params.key?(:event_id)
+        query['edm_aggregatedCHO.edm_wasPresentAt_id'] = BSON::ObjectId.from_string(params[:event_id])
+      end
+    end
   end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class StoriesController < ApplicationController
+  # TODO: filter stories by status, once implemented
+  # TODO: filter stories by EDM::Event from params
+  # TODO: filter events by authorisation
+  def index
+    authorize! :manage, :all
+    @stories = ORE::Aggregation.all
+    @events = EDM::Event.all
+  end
+end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -5,7 +5,7 @@ class StoriesController < ApplicationController
   # TODO: filter stories by EDM::Event from params
   # TODO: filter events by authorisation
   def index
-    authorize! :manage, :all
+    authorize! :index, ORE::Aggregation
     @stories = ORE::Aggregation.all
     @events = EDM::Event.all
   end

--- a/app/helpers/stories_helper.rb
+++ b/app/helpers/stories_helper.rb
@@ -1,0 +1,2 @@
+module StoriesHelper
+end

--- a/app/helpers/stories_helper.rb
+++ b/app/helpers/stories_helper.rb
@@ -1,2 +1,0 @@
-module StoriesHelper
-end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,7 +11,10 @@ class Ability
     when :admin
       can :manage, :all
     when :events
-      # can what?
+      can :index, ORE::Aggregation
+      can :edit, ORE::Aggregation do |aggregation|
+        user.event_ids.include?(aggregation.edm_aggregatedCHO.edm_wasPresentAt_id)
+      end
     end
   end
 end

--- a/app/models/edm/provided_cho.rb
+++ b/app/models/edm/provided_cho.rb
@@ -88,7 +88,10 @@ module EDM
         field :dcterms_medium
         field :dcterms_spatial_places
         field :edm_currentLocation
-        field :edm_wasPresentAt
+        field :edm_wasPresentAt do
+          inline_add false
+          inline_edit false
+        end
       end
     end
 

--- a/app/models/ore/aggregation.rb
+++ b/app/models/ore/aggregation.rb
@@ -21,6 +21,8 @@ module ORE
     index({ edm_provider: 1 })
     index({ created_at: 1 })
     index({ updated_at: 1 })
+    index('edm_aggregatedCHO.edm_type': 1)
+    index('edm_aggregatedCHO.edm_wasPresentAt_id': 1)
 
     embeds_one :edm_aggregatedCHO, class_name: 'EDM::ProvidedCHO', autobuild: true, cascade_callbacks: true
     embeds_one :edm_isShownBy, class_name: 'EDM::WebResource', inverse_of: :edm_isShownBy_for, cascade_callbacks: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,8 @@ class User
 
   field :role, type: Symbol
 
+  has_and_belongs_to_many :events, class_name: 'EDM::Event', inverse_of: nil
+
   def self.role_enum
     %i(admin events)
   end
@@ -80,6 +82,9 @@ class User
       end
       field :password_confirmation do
         required true
+      end
+      field :events do
+        inline_add false
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,12 +77,8 @@ class User
           User.role_enum.reject { |role| bindings[:view].current_user == bindings[:object] && bindings[:object].role != role }
         end
       end
-      field :password do
-        required true
-      end
-      field :password_confirmation do
-        required true
-      end
+      field :password
+      field :password_confirmation
       field :events do
         inline_add false
       end

--- a/app/presenters/stories/index.rb
+++ b/app/presenters/stories/index.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Stories
+  class Index < ApplicationPresenter
+#     def content
+#       mustache[:content] ||= begin
+#         {
+#           title: page_content_heading
+#         }
+#       end
+#     end
+
+#     def flash_notice
+#       flash[:notice]
+#     end
+
+#     def begin_link
+#       {
+#         url: new_migration_path,
+#         text: t('begin_link')
+#       }
+#     end
+
+#     def call_to_action
+#       t('call_to_action')
+#     end
+
+#     def page_content_heading
+#       t('title')
+#     end
+
+#     protected
+
+#     def t(*args, **options)
+#       I18n.t(*args, options.reverse_merge(scope: 'site.campaigns.migration.pages.index'))
+#     end
+  end
+end

--- a/app/presenters/stories/index.rb
+++ b/app/presenters/stories/index.rb
@@ -2,37 +2,61 @@
 
 module Stories
   class Index < ApplicationPresenter
-#     def content
-#       mustache[:content] ||= begin
-#         {
-#           title: page_content_heading
-#         }
-#       end
-#     end
+    def content
+      mustache[:content] ||= begin
+        {
+          title: page_content_heading,
+          stories: stories_content
+        }
+      end
+    end
 
-#     def flash_notice
-#       flash[:notice]
-#     end
+    # TODO: i18n
+    def page_content_heading
+      'Stories'
+    end
 
-#     def begin_link
-#       {
-#         url: new_migration_path,
-#         text: t('begin_link')
-#       }
-#     end
+    protected
 
-#     def call_to_action
-#       t('call_to_action')
-#     end
+    def stories_content
+      {
+        table: {
+          head_data: stories_table_head_data,
+          row_data: stories_table_row_data
+        }
+      }
+    end
 
-#     def page_content_heading
-#       t('title')
-#     end
+    # TODO: i18n
+    def stories_table_head_data
+      ['name', 'ticket number', 'submission date', 'status', 'contains media']
+    end
 
-#     protected
+    def stories_table_row_data
+      @stories.map do |story|
+        {
+          id: story.id,
+          url: '',
+          cells: story_table_row_data_cell(story)
+        }
+      end
+    end
 
-#     def t(*args, **options)
-#       I18n.t(*args, options.reverse_merge(scope: 'site.campaigns.migration.pages.index'))
-#     end
+    # [
+    #   'edm:aggregatedCHO/dc:contributor/foaf:name',
+    #   'edm:aggregatedCHO/dc:identifier',
+    #   'created_at',
+    #   'AASM status',
+    #   'has media?
+    # ]
+    def story_table_row_data_cell(story)
+      [
+        story.edm_aggregatedCHO&.dc_contributor&.foaf_name,
+        story.edm_aggregatedCHO&.dc_identifier,
+        story.created_at,
+        '', # story.status,
+        [story.edm_isShownBy, story.edm_hasViews].any?(&:present?) ? '✔' : '✘'
+      ]
+    end
   end
 end

--- a/app/presenters/stories/index.rb
+++ b/app/presenters/stories/index.rb
@@ -20,11 +20,23 @@ module Stories
 
     def stories_content
       {
+        has_events: @events.present?,
+        events: stories_events,
         table: {
+          has_row_selectors: false, # until we make use of the buttons
           head_data: stories_table_head_data,
           row_data: stories_table_row_data
         }
       }
+    end
+
+    def stories_events
+      @events.map do |event|
+        {
+          url: stories_path(event_id: event.id),
+          label: event.name
+        }
+      end.unshift({ url: stories_path, label: ''})
     end
 
     # TODO: i18n

--- a/app/presenters/stories/index.rb
+++ b/app/presenters/stories/index.rb
@@ -36,7 +36,7 @@ module Stories
           url: stories_path(event_id: event.id),
           label: event.name
         }
-      end.unshift({ url: stories_path, label: ''})
+      end.unshift(url: stories_path, label: '')
     end
 
     # TODO: i18n

--- a/app/views/migration/index.html.mustache
+++ b/app/views/migration/index.html.mustache
@@ -1,3 +1,3 @@
 {{>atoms/meta/_head}}
-{{>templates/Stories/Stories-Index}}
+{{>templates/Stories/Stories-Campaign-Landing}}
 {{>atoms/meta/_foot}}

--- a/app/views/stories/index.html.mustache
+++ b/app/views/stories/index.html.mustache
@@ -1,0 +1,2 @@
+{{>atoms/meta/_head}}
+{{>atoms/meta/_foot}}

--- a/app/views/stories/index.html.mustache
+++ b/app/views/stories/index.html.mustache
@@ -1,2 +1,3 @@
 {{>atoms/meta/_head}}
+{{>templates/Stories/Stories-Index}}
 {{>atoms/meta/_foot}}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,9 @@ Rails.application.routes.draw do
 
   root to: redirect('/migration')
 
-  resources :migration, only: %w(index new create)
+  resources :stories, only: :index
+
+  resources :migration, only: %i(index new create)
 
   get 'oai', to: 'oai#index'
 

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StoriesController do
   describe '#index' do
     context 'when user is authorised' do
       before do
-        allow(subject).to receive(:current_user) { create(:user, role: :admin) }
+        allow(subject).to receive(:current_user) { create(:user, role: :events) }
       end
 
       it 'responds with status code 200' do

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe StoriesController do
+  describe '#index' do
+    context 'when user is authorised' do
+      before do
+        allow(subject).to receive(:current_user) { create(:user, role: :admin) }
+      end
+
+      it 'responds with status code 200' do
+        get :index
+        expect(response.status).to eq(200)
+      end
+
+      it 'assigns stories to @stories' do
+        3.times { create(:ore_aggregation) }
+        get :index
+        expect(assigns(:stories)).to be_a(Enumerable)
+        expect(assigns(:stories).size).to eq(3)
+        expect(assigns(:stories).all? { |story| story.is_a?(ORE::Aggregation) }).to be true
+      end
+
+      it 'assigns events to @events' do
+        5.times { create(:edm_event) }
+        get :index
+        expect(assigns(:events)).to be_a(Enumerable)
+        expect(assigns(:events).size).to eq(5)
+        expect(assigns(:events).all? { |event| event.is_a?(EDM::Event) }).to be true
+      end
+
+      it 'renders HTML' do
+        get :index
+        expect(response.content_type).to eq('text/html')
+      end
+    end
+
+    context 'when user is unauthorised' do
+      it 'responds with status code 403' do
+        get :index
+        expect(response.status).to eq(403)
+      end
+
+      it 'renders plain text' do
+        get :index
+        expect(response.content_type).to eq('text/plain')
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -15,11 +15,45 @@ RSpec.describe Ability do
     let(:user) { build(:user, role: :events) }
 
     it { is_expected.not_to be_able_to(:manage, :all) }
+
+    describe 'stories' do
+      let(:story) { build(:ore_aggregation) }
+      let(:event) { build(:edm_event) }
+
+      it { is_expected.not_to be_able_to(:manage, ORE::Aggregation) }
+      it { is_expected.to be_able_to(:index, ORE::Aggregation) }
+
+      context 'when user is associated with event' do
+        before { user.events.push(event) }
+
+        context 'and story is too' do
+          before { story.edm_aggregatedCHO.edm_wasPresentAt = event }
+          it { is_expected.to be_able_to(:edit, story) }
+        end
+
+        context 'but story is not' do
+          it { is_expected.not_to be_able_to(:edit, story) }
+        end
+      end
+
+      context 'when user is not associated with event' do
+        context 'and neither is story' do
+          it { is_expected.not_to be_able_to(:edit, story) }
+        end
+
+        context 'but story is' do
+          before { story.edm_aggregatedCHO.edm_wasPresentAt = event }
+          it { is_expected.not_to be_able_to(:edit, story) }
+        end
+      end
+    end
   end
 
   context 'when user has no role' do
     let(:user) { build(:user, role: nil) }
 
     it { is_expected.not_to be_able_to(:manage, :all) }
+    it { is_expected.not_to be_able_to(:manage, ORE::Aggregation) }
+    it { is_expected.not_to be_able_to(:index, ORE::Aggregation) }
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'cancan/matchers'
+
+RSpec.describe Ability do
+  subject { described_class.new(user) }
+
+  context 'when user has role :admin' do
+    let(:user) { build(:user, role: :admin) }
+
+    it { is_expected.to be_able_to(:manage, :all) }
+  end
+
+  context 'when user has role :events' do
+    let(:user) { build(:user, role: :events) }
+
+    it { is_expected.not_to be_able_to(:manage, :all) }
+  end
+
+  context 'when user has no role' do
+    let(:user) { build(:user, role: nil) }
+
+    it { is_expected.not_to be_able_to(:manage, :all) }
+  end
+end

--- a/spec/routing/oai_spec.rb
+++ b/spec/routing/oai_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'routes for /oai' do
-  it 'routes GET / to OAIController#index' do
+  it 'routes GET /oai to OAIController#index' do
     expect(get('/oai')).to route_to('oai#index')
   end
 end

--- a/spec/routing/stories_spec.rb
+++ b/spec/routing/stories_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe 'routes for /oai' do
+  it 'routes GET /stories to StoriesController#index' do
+    expect(get('/stories')).to route_to('stories#index')
+  end
+end


### PR DESCRIPTION
* Adds Mongo indexes. Run `bundle exec rake db:mongoid:create_indexes`
* Users are associated with events. A user with role `:events` may only edit stories associated with those events.
* A first iteration of the stories list table is presented at /stories
