### PR TITLE
Dereference vocabulary URIs

### DIFF
--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -47,7 +47,7 @@ class MigrationController < ApplicationController
       redirect_to controller: :stories, action: :index, c: 'eu-migration'
     else
       build_aggregation_associations_unless_present(@aggregation)
-      render action: :edit, status: 400
+      render action: :new, status: 400
     end
   end
 

--- a/app/controllers/vocabularies/europeana/places_controller.rb
+++ b/app/controllers/vocabularies/europeana/places_controller.rb
@@ -13,7 +13,18 @@ module Vocabularies
                        text: :index_result_text,
                        value: 'id'
 
+      # TODO: individual entity retrieval from API does not include isPartOf :(
+      vocabulary_show url: ->(uri) { Rails.application.config.x.europeana.entities.api_url + '/entities' + uri.path },
+                      params: {
+                        wskey: Rails.application.secrets.europeana_entities_api_key
+                      },
+                      text: :show_text
+
       protected
+
+      def show_text(response)
+        index_result_text(response)
+      end
 
       def index_result_text(result)
         candidates = index_result_text_candidates(result)
@@ -43,6 +54,7 @@ module Vocabularies
 
       # Find and return the first candidate matching the regex
       def index_result_text_matching_query(candidates)
+        return nil unless params.key?(:q)
         query = params[:q].downcase
 
         candidates.each do |candidate|

--- a/app/controllers/vocabularies/unesco_controller.rb
+++ b/app/controllers/vocabularies/unesco_controller.rb
@@ -4,14 +4,30 @@ module Vocabularies
   class UNESCOController < VocabulariesController
     vocabulary_index url: 'http://vocabularies.unesco.org/browser/rest/v1/thesaurus/search',
                      params: {
-                       format: 'application/ld+json', lang: 'en', maxhits: 10
+                       format: 'application/ld+json', lang: 'en', maxhits: 10, type: 'skos:Concept'
                      },
                      query: :query,
                      results: 'results',
                      text: :index_result_text,
                      value: 'uri'
 
+#http://vocabularies.unesco.org/browser/rest/v1/thesaurus/data?uri=http://vocabularies.unesco.org/thesaurus/concept10596&format=application/json
+      vocabulary_show url: 'http://vocabularies.unesco.org/browser/rest/v1/thesaurus/data',
+                      params: {
+                        format: 'application/json',
+                        uri: ->(uri) { uri.to_s }
+                      },
+                      text: :show_text
+
     protected
+
+    def show_text(response)
+      item_data = response['graph'].detect { |item| item['uri'] == params['uri'] }
+      translation = item_data['prefLabel'].detect { |pl| pl['lang'] == I18n.locale.to_s } ||
+        item_data['prefLabel'].detect { |pl| pl['lang'] == I18n.default_locale.to_s } ||
+        item_data['prefLabel'].first
+      translation['value']
+    end
 
     def index_query
       "#{params[:q]}*"

--- a/app/controllers/vocabularies/unesco_controller.rb
+++ b/app/controllers/vocabularies/unesco_controller.rb
@@ -11,21 +11,22 @@ module Vocabularies
                      text: :index_result_text,
                      value: 'uri'
 
-#http://vocabularies.unesco.org/browser/rest/v1/thesaurus/data?uri=http://vocabularies.unesco.org/thesaurus/concept10596&format=application/json
-      vocabulary_show url: 'http://vocabularies.unesco.org/browser/rest/v1/thesaurus/data',
-                      params: {
-                        format: 'application/json',
-                        uri: ->(uri) { uri.to_s }
-                      },
-                      text: :show_text
+    vocabulary_show url: 'http://vocabularies.unesco.org/browser/rest/v1/thesaurus/data',
+                    params: {
+                      format: 'application/json',
+                      uri: ->(uri) { uri.to_s }
+                    },
+                    text: :show_text
 
     protected
 
     def show_text(response)
       item_data = response['graph'].detect { |item| item['uri'] == params['uri'] }
+
       translation = item_data['prefLabel'].detect { |pl| pl['lang'] == I18n.locale.to_s } ||
-        item_data['prefLabel'].detect { |pl| pl['lang'] == I18n.default_locale.to_s } ||
-        item_data['prefLabel'].first
+                    item_data['prefLabel'].detect { |pl| pl['lang'] == I18n.default_locale.to_s } ||
+                    item_data['prefLabel'].first
+
       translation['value']
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   get 'oai', to: 'oai#index'
 
   get 'vocabularies/europeana/places', to: 'vocabularies/europeana/places#index'
+  get 'vocabularies/europeana/places/dereference', to: 'vocabularies/europeana/places#show'
   get 'vocabularies/geonames', to: 'vocabularies/geonames#index'
   get 'vocabularies/unesco', to: 'vocabularies/unesco#index'
+  get 'vocabularies/unesco/dereference', to: 'vocabularies/unesco#show'
 end


### PR DESCRIPTION
Also:
* Fix the render call on the MigrationContoller#update
* Restrict UNESCO API searches to skos:Concept items