### PR TITLE
Switch to dc:creator literal on web resources

### DIFF
--- a/app/controllers/migration_controller.rb
+++ b/app/controllers/migration_controller.rb
@@ -59,7 +59,6 @@ class MigrationController < ApplicationController
     story.ore_aggregation.edm_aggregatedCHO.dc_subject_agents.build unless story.ore_aggregation.edm_aggregatedCHO.dc_subject_agents.present?
     story.ore_aggregation.edm_aggregatedCHO.dcterms_spatial_places.build while story.ore_aggregation.edm_aggregatedCHO.dcterms_spatial_places.size < 2
     story.ore_aggregation.build_edm_isShownBy unless story.ore_aggregation.edm_isShownBy.present?
-    story.ore_aggregation.edm_isShownBy.build_dc_creator_agent unless story.ore_aggregation.edm_isShownBy.dc_creator_agent.present?
   end
 
   def story_defaults
@@ -95,12 +94,8 @@ class MigrationController < ApplicationController
                    dcterms_spatial_places_attributes: [%i(id owl_sameAs owl_sameAs_autocomplete)]
                  }
                ],
-               edm_isShownBy_attributes: [:dc_description, :dc_type, :dcterms_created, :media, :media_cache, :remove_media, {
-                 dc_creator_agent_attributes: [:foaf_name]
-               }],
-               edm_hasViews_attributes: [[:id, :_destroy, :dc_description, :dc_type, :dcterms_created, :media, :media_cache, :remove_media, {
-                 dc_creator_agent_attributes: [:foaf_name]
-               }]]
+               edm_isShownBy_attributes: %i(dc_creator dc_description dc_type dcterms_created media media_cache remove_media),
+               edm_hasViews_attributes: [%i(id _destroy dc_creator dc_description dc_type dcterms_created media media_cache remove_media)]
              })
   end
 

--- a/app/models/edm/web_resource.rb
+++ b/app/models/edm/web_resource.rb
@@ -33,6 +33,7 @@ module EDM
     validate :europeana_supported_media_mime_type, unless: proc { |wr| wr.media.blank? }
     validates_associated :dc_creator_agent
 
+    field :dc_creator, type: String
     field :dc_description, type: String
     field :dc_rights, type: String
     field :dc_type, type: String
@@ -47,7 +48,7 @@ module EDM
       field :dc_rights
       field :dc_type
       field :dcterms_created
-      field :dc_creator_agent
+      field :dc_creator
       field :edm_rights do
         inline_add false
         inline_edit false

--- a/app/views/migration/_form.html.erb
+++ b/app/views/migration/_form.html.erb
@@ -54,9 +54,7 @@
             <%= wr.input(:dc_description) %>
             <%= wr.input(:dc_type) %>
             <%= wr.input(:dcterms_created, as: :date, html5: true, input_html: date_format_fallback_attributes) %>
-            <%= wr.simple_fields_for(:dc_creator_agent) do |creator| %>
-              <%= creator.input(:foaf_name) %>
-            <% end %>
+            <%= wr.input(:dc_creator) %>
           <% end %>
         <% end %>
 
@@ -76,9 +74,7 @@
             <%= wr.input(:dc_description) %>
             <%= wr.input(:dc_type) %>
             <%= wr.input(:dcterms_created, as: :date, html5: true, input_html: date_format_fallback_attributes) %>
-            <%= wr.simple_fields_for(:dc_creator_agent) do |creator| %>
-              <%= creator.input(:foaf_name) %>
-            <% end %>
+            <%= wr.input(:dc_creator) %>
           <% end %>
         <% end %>
         <%= agg.add_nested_fields_link(:edm_hasViews, i18n.t('buttons.object.add')) %>


### PR DESCRIPTION
Agent is implied by dc:creator

NB: the field label will be "DC creator" on this branch, but that will be resolved when we switch to using europeana-i18n for the form field labels in #79 